### PR TITLE
Update Makefile.am after #13179

### DIFF
--- a/tools/depends/native/TexturePacker/src/Makefile.am
+++ b/tools/depends/native/TexturePacker/src/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS = \
   -I@KODI_SRC_DIR@/lib \
   -I@KODI_SRC_DIR@/xbmc \
   -I@KODI_SRC_DIR@/xbmc/guilib \
-  -I@KODI_SRC_DIR@/xbmc/linux \
+  -I@KODI_SRC_DIR@/xbmc/platform/linux \
   @CPPFLAGS@
 
 AM_LDFLAGS = @LIBS@ @STATIC_FLAG@


### PR DESCRIPTION
It fixes build of TexturePacker after https://github.com/xbmc/xbmc/pull/13179